### PR TITLE
Fix for RuntimeError for Environments with single continuous actions.

### DIFF
--- a/PPO.py
+++ b/PPO.py
@@ -124,7 +124,9 @@ class ActorCritic(nn.Module):
             cov_mat = torch.diag_embed(action_var).to(device)
             dist = MultivariateNormal(action_mean, cov_mat)
             
-            action = action.reshape(-1, self.action_dim)
+            # For Single Action Environments.
+            if self.action_dim == 1:
+                action = action.reshape(-1, self.action_dim)
 
         else:
             action_probs = self.actor(state)

--- a/PPO.py
+++ b/PPO.py
@@ -123,10 +123,12 @@ class ActorCritic(nn.Module):
             action_var = self.action_var.expand_as(action_mean)
             cov_mat = torch.diag_embed(action_var).to(device)
             dist = MultivariateNormal(action_mean, cov_mat)
+            
+            action = action.reshape(-1, self.action_dim)
+
         else:
             action_probs = self.actor(state)
             dist = Categorical(action_probs)
-        action = action.reshape(-1, self.action_dim)
         action_logprobs = dist.log_prob(action)
         dist_entropy = dist.entropy()
         state_values = self.critic(state)

--- a/PPO.py
+++ b/PPO.py
@@ -119,13 +119,14 @@ class ActorCritic(nn.Module):
 
         if self.has_continuous_action_space:
             action_mean = self.actor(state)
+            
             action_var = self.action_var.expand_as(action_mean)
             cov_mat = torch.diag_embed(action_var).to(device)
             dist = MultivariateNormal(action_mean, cov_mat)
         else:
             action_probs = self.actor(state)
             dist = Categorical(action_probs)
-
+        action = action.reshape(-1, self.action_dim)
         action_logprobs = dist.log_prob(action)
         dist_entropy = dist.entropy()
         state_values = self.critic(state)


### PR DESCRIPTION
For environments with action shape `( 1 ,  )` , the action values are in a 1D array instead of being in batches. 
Minor changes for fixing it 